### PR TITLE
feat: Increase vertical spacing between globe icons

### DIFF
--- a/FirstXcodeFork/ContentView.swift
+++ b/FirstXcodeFork/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
     
     @State var names: [String] = []
     var body: some View {
-        VStack {
+        VStack(spacing: 60) {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)


### PR DESCRIPTION
- Added `spacing: 60` to the nested `VStack` for better visual separation.
- Retained existing system images and tint styling.